### PR TITLE
feat(sa): introduce Semantik-Anker v0.9 (spec + validator + CI)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,15 @@
+cff-version: 1.2.0
+message: "Bitte zitieren Sie dieses Projekt wie unten angegeben."
+title: "Semantik-Anker (sa::) — Norm v0.9 (Draft)"
+version: "0.9"
+date-released: "2025-08-20"
+authors:
+  - family-names: Schloemer
+    given-names: Joost
+license: "CC-BY-4.0"
+type: standard
+repository-code: "https://github.com/Schloemer-CMS/semantik-anker"  # placeholder
+abstract: >
+  Der Semantik-Anker (sa::) ist eine geordnete Bedeutungs-Kette. Diese
+  Veröffentlichung enthält die v0.9-Spezifikation, Beispiele, einen Validator
+  und eine CI-Integration.

--- a/anchor.jsonld
+++ b/anchor.jsonld
@@ -1,0 +1,14 @@
+{
+  "@context": {
+    "sa": "https://example.org/sa#"
+  },
+  "@type": "sa:Anchor",
+  "sa:chain": [
+    "verein",
+    "datenschutz",
+    "hinweisgebersystem",
+    "vertrauen"
+  ],
+  "sa:lang": "de",
+  "sa:version": "0.9"
+}

--- a/anchors.txt
+++ b/anchors.txt
@@ -1,0 +1,3 @@
+verein::datenschutz::hinweisgebersystem::vertrauen
+pv-projekt::flächenpacht::due-diligence::genehmigung
+vereinsplattform::onboarding::moderation::risiko-reduktion

--- a/sa-validate.js
+++ b/sa-validate.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * sa-validate.js — Minimaler CLI-Validator für Semantik‑Anker (sa::)
+ * Lizenz: MIT (für dieses Tool); Spec unter CC BY 4.0
+ */
+const fs = require('fs');
+
+const RE = /^[a-z0-9][a-z0-9-_\/#]*(::[a-z0-9][a-z0-9-_\/#]*)+$/;
+const MIN_SEG = 3, MAX_SEG = 6, MAX_LEN = 32;
+
+function analyze(chain) {
+  const original = chain;
+  const s = chain.trim().toLowerCase();
+  const okRegex = RE.test(s);
+  const segments = s.split('::');
+  const hints = [];
+
+  if (!okRegex) hints.push('Regex-Fehler (Zeichen/Syntax)');
+  if (segments.length < MIN_SEG || segments.length > MAX_SEG) {
+    hints.push(`Segmentanzahl ${segments.length} ist außerhalb 3–6`);
+  }
+  for (const seg of segments) {
+    if (!seg) hints.push('Leeres Segment');
+    if (seg.length > MAX_LEN) hints.push(`Segment zu lang: "${seg}" (${seg.length})`);
+    if (/^(und|allgemein|misc|divers)$/.test(seg)) hints.push(`Unpräzises Segment: "${seg}"`);
+  }
+  return {
+    input: original,
+    normalized: s,
+    valid: okRegex && hints.length === 0,
+    segments,
+    hints
+  };
+}
+
+function printHuman(res) {
+  const status = res.valid ? 'OK' : 'FAIL';
+  const hint = res.hints.length ? ' — ' + res.hints.join('; ') : '';
+  console.log(`${status}: ${res.input}${hint}`);
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const json = args.includes('--json');
+  const fileIdx = args.indexOf('--file');
+  const targets = [];
+
+  if (fileIdx !== -1 && args[fileIdx + 1]) {
+    const path = args[fileIdx + 1];
+    const content = fs.readFileSync(path, 'utf8');
+    content.split(/\r?\n/).forEach(line => {
+      if (line.trim()) targets.push(line.trim());
+    });
+  } else {
+    // Remaining args treated as chains unless none: then read stdin
+    const argChains = args.filter(a => !a.startsWith('--'));
+    if (argChains.length) {
+      targets.push(...argChains);
+    } else {
+      const data = fs.readFileSync(0, 'utf8'); // stdin
+      data.split(/\r?\n/).forEach(line => {
+        if (line.trim()) targets.push(line.trim());
+      });
+    }
+  }
+
+  if (!targets.length) {
+    console.error('Usage: node sa-validate.js [--json] [--file path] [chain ...]');
+    process.exit(2);
+  }
+
+  let anyFail = false;
+  for (const t of targets) {
+    const res = analyze(t);
+    if (json) {
+      console.log(JSON.stringify(res));
+    } else {
+      printHuman(res);
+    }
+    if (!res.valid) anyFail = true;
+  }
+  process.exit(anyFail ? 1 : 0);
+}
+
+if (require.main === module) main();

--- a/sa-validate.yml
+++ b/sa-validate.yml
@@ -1,0 +1,25 @@
+name: sa-validate
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Run validator on examples
+        run: |
+          node tools/sa-validate.js --file examples/anchors.txt
+      - name: Scan repository for data-sa attributes (HTML/MDX)
+        run: |
+          grep -Rho 'data-sa="[^"]\+"' . || true | sed 's/.*data-sa="//;s/".*//' > .anchors || true
+          if [ -s .anchors ]; then
+            node tools/sa-validate.js --file .anchors
+          else
+            echo "No data-sa attributes found. Skipping."
+          fi

--- a/semantik-anker-spec-v0.9.md
+++ b/semantik-anker-spec-v0.9.md
@@ -1,0 +1,82 @@
+# Semantik‑Anker (sa::) — Norm v0.9 (Draft)
+
+**Status:** Draft v0.9 • **Lizenz:** CC BY 4.0 • **Maintainer:** Joost Schloemer (Proponent) • **Kurzbezeichnung:** *sa::*
+
+## 1. Zweck und Geltungsbereich
+Ein **Semantik‑Anker** (sa::) ist eine **geordnet‑deterministische Bedeutungs­kette** aus Segmenten. Die Kette bindet eine Entität an Facette/Funktion, Kontext, Intention/Ziel und erwartete Wirkung. **Die Reihenfolge ist bedeutungstragend.**  
+In‑Scope: KI/LLM‑Prompting, SEO/SGE, Wissensgraphen, Content‑Architektur, Compliance‑Dokumentation. Out‑of‑Scope v0.9: automatische Ontologie‑Ableitung, Synonymerkennung, Morphologie.
+
+## 2. Begriffe
+- **Kette (Chain):** Folge von Segmenten, getrennt durch „::“.
+- **Segment:** Atomarer Bedeutungsbaustein (ASCII, lowercase).
+- **Strict Mode:** Minimale, robuste Norm; **Extended Mode:** optionale Erweiterungen (Umlaut‑Escapes u. ä.).
+- **Normalisierung:** Technische Vereinheitlichung (Lowercasing, Trimmen), ohne inhaltliche Synonymisierung.
+
+## 3. Syntax (normativ)
+- **Form:** `segment(::segment)+`
+- **Segment (Strict Mode):** Zeichensatz `a–z 0–9 - _ / #` (ASCII, lowercase).
+- **Längenempfehlung:** Segmente ≤ 32 Zeichen; Kettenlänge 3–6 Segmente.
+- **Empfohlene Slot‑Logik (informativ):** `Entität :: Facette/Funktion :: Kontext :: Ziel/Intention :: Wirkung`
+
+**EBNF (Strict Mode):**
+```
+ANCHOR  := CHAIN ;
+CHAIN   := SEGMENT { "::" SEGMENT } ;
+SEGMENT := ALNUM { ALNUM | "-" | "_" | "/" | "#" } ;
+ALNUM   := "a"…"z" | "0"…"9" ;
+```
+**Regex (Strict Mode):**
+```
+^[a-z0-9][a-z0-9-_\/#]*(::[a-z0-9][a-z0-9-_\/#]*)+$
+```
+
+## 4. Verarbeitungsregeln (normativ)
+1. **Link‑nach‑rechts‑Spezifizierung:** Jedes folgende Segment verengt den Bedeutungsraum des vorherigen.
+2. **Ordnungspflicht:** Vertauschen von Segmenten ändert die Bedeutung.
+3. **Stabilität:** Dieselbe Kette MUSS versionstreu dieselbe Bedeutung transportieren.
+4. **Normalisierung:** Parser MÜSSEN Lowercasing und Trimmen durchführen; automatisches Synonym‑Mapping ist NICHT zulässig.
+5. **Sprachregel:** Pro Kette EIN Sprache‑Kontext (z. B. de oder en).
+
+## 5. Serialisierung (JSON‑LD, informativ)
+```json
+{
+  "@context": {"sa":"https://example.org/sa#"},
+  "@type": "sa:Anchor",
+  "sa:chain": ["verein","datenschutz","hinweisgebersystem","vertrauen"],
+  "sa:lang": "de",
+  "sa:version": "0.9"
+}
+```
+**HTML‑Attribut (Crawl‑Hinweis):**
+```html
+<article data-sa="verein::datenschutz::hinweisgebersystem::vertrauen">…</article>
+```
+
+## 6. Konformität
+- **sa:: Strict‑konform:** erfüllt Regex, keine leeren/duplizierten Trennzeichen, 3–6 Segmente.
+- **sa:: Extended‑konform:** Strict + optionale Escapes (z. B. `ä -> ae`). Extended MUSS nach Strict normalisierbar sein.
+
+## 7. Beispiele (gültig)
+- `verein::datenschutz::hinweisgebersystem::vertrauen`
+- `pv-projekt::flächenpacht::due-diligence::genehmigung`
+- `vereinsplattform::onboarding::moderation::risiko-reduktion`
+
+**Gegenbeispiele**
+- `verein::::datenschutz` (leeres Segment)
+- `Verein::DatenSchutz` (Case‑Mix, nicht normalisiert)
+- `allgemein::thema::misc` (unkonkret)
+
+## 8. Sicherheit & Datenschutz (informativ)
+- **Privacy:** Ketten KÖNNEN sensible Begriffe enthalten; Betreiber SOLLTEN Klassifikationen für Export/Logging vorsehen.
+- **Security:** Validatoren SOLLTEN Input‑Längen und Zeichensätze strikt prüfen (ReDoS/Injection vermeiden).
+
+## 9. Versionierung & Governance
+- **SemVer:** v0.9 (Draft) → v1.0 (Stabil nach RFC‑Phase).
+- **Artefakte:** Spezifikation (dieses Dokument), Beispiele, Parser (JS/Python), Validator (CLI), Changelog.
+- **Änderungsprozess:** Öffentliche RFC‑Issues, Review durch Maintainer‑Team (1 Editor, 2 Reviewer).
+
+## 10. Zitierweise
+> Schloemer, J. (2025): Semantik‑Anker (sa::) — Norm v0.9 (Draft). CC BY 4.0. DOI: _wird bei Release hinterlegt_.
+
+---
+**Changelog:** v0.9 (Draft, 2025‑08‑20): Erstveröffentlichung.


### PR DESCRIPTION
### Inhalt
- Spezifikation: `spec/semantik-anker-spec-v0.9.md`
- Validator: `tools/sa-validate.js`
- Beispiele: `examples/anchors.txt`, `examples/anchor.jsonld`
- CI: `.github/workflows/sa-validate.yml`
- Zitation/Lizenzen: `CITATION.cff`, `LICENSES/*`

### Warum
sa:: bindet Bedeutung an Ordnung (deterministische Ketten) – nutzbar für Prompting, SEO/SGE, Wissensgraphen.

### Checks
- [ ] CI Grün (Validator läuft)
- [ ] README-Hinweis auf sa:: ergänzt (folgt im separaten Commit/PR)
